### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,13 +2,13 @@ name: Check for new Grpc release
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:
   check-release:
     runs-on: ubuntu-18.04
-    
+
     outputs:
       latest-release: ${{ steps.latest.outputs.LATEST_RELEASE }}
       current-release: ${{ steps.current.outputs.CURRENT_RELEASE }}
@@ -21,18 +21,18 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y curl jq
-          
+
           GRPC_LATEST=$(curl -s https://pypi.org/pypi/grpcio/json | jq -r '.info.version')
-          echo "LATEST_RELEASE=" >> "$GITHUB_OUTPUT"$GRPC_LATEST
+          echo "LATEST_RELEASE=$GRPC_LATEST" >> "$GITHUB_OUTPUT"
           echo "Latest Grpc version: $GRPC_LATEST"
-          
+
       - name: Get current Grpc release for s390x
         id: current
         run: |
           GRPC_CURRENT=$(curl -s https://api.github.com/repos/IBM/grpc-for-Z/releases/latest | grep tag_name | cut -d '"' -f4)
-          echo "CURRENT_RELEASE=" >> "$GITHUB_OUTPUT"$GRPC_CURRENT
+          echo "CURRENT_RELEASE=$GRPC_CURRENT" >> "$GITHUB_OUTPUT"
           echo "Current Grpc version on IBMZ: $GRPC_CURRENT"
-          
+
   build-new-release:
     needs: [check-release]
     if: ${{ needs.check-release.outputs.latest-release }} != ${{ needs.check-release.outputs.current-release }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,14 +23,14 @@ jobs:
           sudo apt-get install -y curl jq
           
           GRPC_LATEST=$(curl -s https://pypi.org/pypi/grpcio/json | jq -r '.info.version')
-          echo '::set-output name=LATEST_RELEASE::'$GRPC_LATEST
+          echo "LATEST_RELEASE=" >> "$GITHUB_OUTPUT"$GRPC_LATEST
           echo "Latest Grpc version: $GRPC_LATEST"
           
       - name: Get current Grpc release for s390x
         id: current
         run: |
           GRPC_CURRENT=$(curl -s https://api.github.com/repos/IBM/grpc-for-Z/releases/latest | grep tag_name | cut -d '"' -f4)
-          echo '::set-output name=CURRENT_RELEASE::'$GRPC_CURRENT
+          echo "CURRENT_RELEASE=" >> "$GITHUB_OUTPUT"$GRPC_CURRENT
           echo "Current Grpc version on IBMZ: $GRPC_CURRENT"
           
   build-new-release:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter